### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build-check.yml
+++ b/.github/workflows/build-check.yml
@@ -1,5 +1,8 @@
 name: Build Check
 
+permissions:
+  contents: read
+
 on:
   # Trigger on pull requests to main branch
   pull_request:


### PR DESCRIPTION
Potential fix for [https://github.com/KSS-IT-Committee/2026-sousakuten-info/security/code-scanning/1](https://github.com/KSS-IT-Committee/2026-sousakuten-info/security/code-scanning/1)

Add an explicit `permissions` block at the workflow root so it applies to all jobs (`build`, `lint`, `checks-summary`) consistently.

Best fix here:
- In `.github/workflows/build-check.yml`, insert after the `name:` line (before `on:`):
  - `permissions:`
  - `contents: read`

Why this is best:
- Minimal required scope for current steps (notably checkout).
- No functional workflow changes expected.
- Centralized configuration avoids repeating the same permission block in each job.
- Satisfies CodeQL requirement and documents intended token privileges.

No imports/methods/dependencies are needed (YAML config only).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
