### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build-check.yml
+++ b/.github/workflows/build-check.yml
@@ -1,5 +1,8 @@
 name: Build Check
 
+permissions:
+  contents: read
+
 on:
   # Trigger on pull requests to main branch
   pull_request:


### PR DESCRIPTION
Potential fix for [https://github.com/KSS-IT-Committee/2026-sousakuten-info/security/code-scanning/2](https://github.com/KSS-IT-Committee/2026-sousakuten-info/security/code-scanning/2)

To fix this, add an explicit `permissions` block to the workflow so all jobs inherit least-privilege token access.

Best single fix without changing functionality:
- Edit `.github/workflows/build-check.yml`.
- Add a root-level `permissions` section directly under `name` (before `on` is typical and clear):
  - `contents: read`

Why this is sufficient:
- `actions/checkout@v4` requires `contents: read`.
- The rest of the workflow (cache, npm install/build/lint, shell checks) does not require write permissions to repository resources.
- A workflow-level block applies to `build`, `lint`, and `checks-summary` jobs unless overridden, keeping config minimal and consistent.

No imports, methods, or additional definitions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
