### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build-check.yml
+++ b/.github/workflows/build-check.yml
@@ -12,6 +12,9 @@ on:
   # Allow manual trigger from Actions tab
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   build:
     name: Build and Type Check


### PR DESCRIPTION
Potential fix for [https://github.com/KSS-IT-Committee/2026-sousakuten-info/security/code-scanning/3](https://github.com/KSS-IT-Committee/2026-sousakuten-info/security/code-scanning/3)

Add an explicit top-level `permissions` block in `.github/workflows/build-check.yml` so all jobs inherit least-privilege token access.

Best fix (without changing functionality): define workflow-level permissions as read-only for repository contents:
- `permissions:`
  - `contents: read`

Why this is best here:
- All jobs in this workflow are CI checks (checkout, install, build, lint, summary) and do not need write scopes.
- `actions/checkout` needs `contents: read`.
- Setting at workflow root avoids duplication and ensures consistent permissions across all jobs, including future ones unless overridden.

Change location:
- In `.github/workflows/build-check.yml`, insert the `permissions` block after triggers (`on:` section) and before `jobs:`.

No imports, methods, or dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
