### PR TITLE
Validate DATABASE_URL and defer db client init

### DIFF
--- a/drizzle.config.ts
+++ b/drizzle.config.ts
@@ -4,5 +4,9 @@ export default {
   schema: "./db/schema.ts",
   out: "./drizzle",
   dialect: "postgresql",
-  dbCredentials: { url: process.env.DATABASE_URL! },
+  get dbCredentials() {
+    const url = process.env.DATABASE_URL;
+    if (!url) throw new Error("DATABASE_URL is not set");
+    return { url };
+  },
 } satisfies Config;

--- a/lib/db.ts
+++ b/lib/db.ts
@@ -1,4 +1,6 @@
-import { drizzle } from "drizzle-orm/postgres-js";
+import "server-only";
+
+import { drizzle, type PostgresJsDatabase } from "drizzle-orm/postgres-js";
 import postgres from "postgres";
 
 import * as schema from "@/db/schema";
@@ -8,8 +10,19 @@ declare global {
   var pgClient: ReturnType<typeof postgres> | undefined;
 }
 
-const client =
-  global.pgClient ?? postgres(process.env.DATABASE_URL!, { max: 10 });
-if (process.env.NODE_ENV !== "production") global.pgClient = client;
+type Db = PostgresJsDatabase<typeof schema>;
+let _db: Db | undefined;
 
-export const db = drizzle(client, { schema });
+function getDb(): Db {
+  if (_db) return _db;
+  const databaseUrl = process.env.DATABASE_URL;
+  if (!databaseUrl) throw new Error("DATABASE_URL is not set");
+  const client = global.pgClient ?? postgres(databaseUrl, { max: 10 });
+  if (process.env.NODE_ENV !== "production") global.pgClient = client;
+  _db = drizzle(client, { schema });
+  return _db;
+}
+
+export const db = new Proxy({} as Db, {
+  get: (_target, prop) => Reflect.get(getDb(), prop),
+});


### PR DESCRIPTION
Replace non-null-asserted DATABASE_URL access with explicit checks that
throw when unset, and lazily initialize the postgres client behind a
Proxy so importing lib/db.ts no longer connects at module load.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
