### PR TITLE
Add role+class gating to AuthGuard/Internal (byte-identical)

### DIFF
--- a/components/AuthGuard/index.tsx
+++ b/components/AuthGuard/index.tsx
@@ -1,51 +1,35 @@
-import { eq } from "drizzle-orm";
 import { forbidden, unauthorized } from "next/navigation";
 
-import { ROLENAMES, users } from "@/db/schema";
-import { db } from "@/lib/db";
+import { hasAccess, type Role } from "@/lib/access";
 import { getCurrentUser } from "@/lib/session";
-
-type Role = (typeof ROLENAMES)[number];
-
-// Mirrors lib/user-category.ts (which lives on the Internal-component branch).
-// Inlined here so this guard stays self-contained; DRY it up once
-// user-category.ts is on main.
-const STUDENT_RE = /^[1-6][A-D]\d{2}$/; // 1A01 … 6D40
-const TEACHER_RE = /^k/; // k-prefixed staff accounts
-
-function isInternal(username: string): boolean {
-  return STUDENT_RE.test(username) || TEACHER_RE.test(username);
-}
+import { isInternal } from "@/lib/user-category";
 
 export async function AuthGuard({
   children,
   role,
+  classCode,
 }: {
   children: React.ReactNode;
   role?: Role | Role[];
+  classCode?: string | string[];
 }) {
   const user = await getCurrentUser();
   if (!user) {
     unauthorized(); // 401 — not logged in
   }
 
-  if (role === undefined) {
-    // No role requested: gate on being an internal (school) user.
+  // No role/class requested: gate on being an internal (school) user.
+  if (role === undefined && classCode === undefined) {
     if (!isInternal(user.username)) {
       forbidden(); // 403
     }
-  } else {
-    // Role requested: the user must hold (one of) it.
-    const required = Array.isArray(role) ? role : [role];
-    const [row] = await db
-      .select({ roles: users.roles })
-      .from(users)
-      .where(eq(users.username, user.username));
-    const userRoles = row?.roles ?? [];
-    if (!required.some((r) => userRoles.includes(r))) {
-      forbidden(); // 403
-    }
+    return <>{children}</>;
   }
 
+  // A constraint was requested: admit the user if they match any of them
+  // (role OR class). Nest guards when ALL must hold.
+  if (!(await hasAccess(user.username, role, classCode))) {
+    forbidden(); // 403
+  }
   return <>{children}</>;
 }

--- a/components/Internal/index.tsx
+++ b/components/Internal/index.tsx
@@ -1,32 +1,29 @@
-import { getUserByUsername } from "@/db/getUserByUsername";
-import { ROLENAMES } from "@/db/schema";
+import { hasAccess, type Role } from "@/lib/access";
 import { getCurrentUser } from "@/lib/session";
 import { isInternal } from "@/lib/user-category";
-
-type Role = (typeof ROLENAMES)[number];
 
 export async function Internal({
   children,
   role,
+  classCode,
 }: {
   children: React.ReactNode;
   role?: Role | Role[];
+  classCode?: string | string[];
 }) {
   const user = await getCurrentUser();
   if (!user || !isInternal(user.username)) {
     return null;
   }
 
-  // When a role is requested, the user must hold (one of) it on top of being
-  // internal. Without the prop, any internal user passes.
-  if (role !== undefined) {
-    const required = Array.isArray(role) ? role : [role];
-    const fullUser = await getUserByUsername(user.username);
-    const userRoles = fullUser?.roles ?? [];
-    if (!required.some((r) => userRoles.includes(r))) {
-      return null;
-    }
+  // No further constraint: any internal user passes.
+  if (role === undefined && classCode === undefined) {
+    return <>{children}</>;
   }
 
-  return <>{children}</>;
+  // Otherwise the user must also match a requested role or class.
+  if (await hasAccess(user.username, role, classCode)) {
+    return <>{children}</>;
+  }
+  return null;
 }

--- a/lib/access.ts
+++ b/lib/access.ts
@@ -1,0 +1,50 @@
+import "server-only";
+
+import { eq } from "drizzle-orm";
+
+import { ROLENAMES, users } from "@/db/schema";
+import { db } from "@/lib/db";
+import { classOf } from "@/lib/user-category";
+
+export type Role = (typeof ROLENAMES)[number];
+
+/**
+ * Whether `username` clears the given role/class constraints. Role and class
+ * are two independent axes: `role` is the shared Role enum (db/schema); `class`
+ * is a class code such as "3B", matched via classOf() (e.g. "3B12" -> "3B").
+ * The user passes by matching ANY constraint supplied — role OR class — so
+ * `<AuthGuard role="IT" classCode="3B">` admits IT members *or* class-3B
+ * students; nest guards when you instead need ALL constraints to hold.
+ *
+ * `classCode` is a plain string (not a per-app class union) so this file stays
+ * byte-identical across the apps, whose class-list modules differ; unknown
+ * codes simply never match. Callers pass at least one constraint — the
+ * "no constraint, just be internal" case is handled by the guards themselves.
+ */
+export async function hasAccess(
+  username: string,
+  role: Role | Role[] | undefined,
+  classCode: string | string[] | undefined,
+): Promise<boolean> {
+  if (classCode !== undefined) {
+    const allowed = Array.isArray(classCode) ? classCode : [classCode];
+    const userClass = classOf(username);
+    if (userClass !== null && allowed.includes(userClass)) {
+      return true;
+    }
+  }
+
+  if (role !== undefined) {
+    const required = Array.isArray(role) ? role : [role];
+    const [row] = await db
+      .select({ roles: users.roles })
+      .from(users)
+      .where(eq(users.username, username));
+    const userRoles = row?.roles ?? [];
+    if (required.some((r) => userRoles.includes(r))) {
+      return true;
+    }
+  }
+
+  return false;
+}


### PR DESCRIPTION
## What

Adds class-based gating to the shared **AuthGuard** / **Internal** components, alongside the existing role gating, and factors the shared check into `lib/access.ts`. Kept **byte-identical** with the other three 2026 apps (companion PRs).

## Changes

- New `lib/access.ts` (`hasAccess`): the role/class access check shared by both guards.
- `AuthGuard` / `Internal` gain an optional `classCode` prop. `role` is the shared `Role` enum; `class` is a class-code string matched via `classOf` (e.g. `"3B12" → "3B"`), so the files stay byte-identical across apps whose class-list modules differ. Existing role / no-arg usages are unaffected (the prop is additive).

## Verification

`tsc --noEmit` and `eslint` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)