### PR TITLE
update top page path

### DIFF
--- a/components/Header/index.tsx
+++ b/components/Header/index.tsx
@@ -30,8 +30,7 @@ export function Header({ accountSlot }: HeaderProps) {
     <header className={`${styles.header} ${isOpen ? styles.open : ""}`}>
       <div className={styles.container}>
         <div className={styles.menu}>
-          <a href="sousakuten-top-page" className={styles.home}>
-            {/* 創作展 */}
+          <a href="https://top.2026.kss-it.com/" className={styles.home}>
             <Image
               src="/theme/event-week.png"
               alt="創作展"

--- a/content/changelog/0128-changelog.json
+++ b/content/changelog/0128-changelog.json
@@ -1,0 +1,5 @@
+{
+  "title": "トップページへの仮のパスを更新",
+  "description": "ヘッダーの画像から top.2026.kss-it.com へ飛ぶようになりました。",
+  "credits": ["@hatuna-827"]
+}


### PR DESCRIPTION
# トップページへの仮のパスを更新

ヘッダーの画像から top.2026.kss-it.com へ飛ぶようになりました。

close #54 