### PR TITLE
fix: treat class-code-prefixed accounts as internal

### DIFF
--- a/lib/user-category.ts
+++ b/lib/user-category.ts
@@ -1,4 +1,4 @@
-const STUDENT_RE = /^[1-6][A-D]\d{2}$/; // 1A01 … 6D40
+const STUDENT_RE = /^[1-6][A-D]\d{2}/; // 1A01 … 6D40 (prefix match: a trailing suffix like 4D11_sakuten still counts — keep unanchored)
 const TEACHER_RE = /^k\d{7}$/; // staff accounts: k + 7 digits, e.g. k0959176
 
 export function isInternal(username: string): boolean {


### PR DESCRIPTION
Unanchor STUDENT_RE so a username like 4D11_sakuten (a valid class code plus a suffix) still passes isInternal() and resolves a class via classOf(). This unblocks role-holding committee/test accounts that were denied on Internal-gated controls and bare AuthGuard pages. Kept byte-identical across all four apps.