### PR TITLE
dependabot(正確にはgha)がchangelogを自動で書けるようにする

### DIFF
--- a/.github/workflows/auto-changelog.yml
+++ b/.github/workflows/auto-changelog.yml
@@ -1,3 +1,5 @@
+name: Auto Changelog
+
 on:
   pull_request_target:
     types: [opened]
@@ -15,11 +17,17 @@ jobs:
         with:
           repository: ${{ github.event.pull_request.head.repo.full_name }}
           ref: ${{ github.event.pull_request.head.ref }}
+          persist-credentials: false
 
       - name: Write log
+        env:
+          BRANCH: ${{ github.event.pull_request.head.ref }}
+          TITLE: ${{ github.event.pull_request.title }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
-          BRANCH="${{ github.event.pull_request.head.ref }}"
-          FILE="content/changelog/$(printf "%04d" ${{ github.event.pull_request.number }}).json"
+          mkdir -p content/changelog
+
+          FILE="content/changelog/$(printf "%04d" "$PR_NUMBER").json"
 
           if [[ "$BRANCH" == dependabot/github_actions/* ]]; then
             DESCRIPTION="Actionのバージョンを上げました。これによるページの変更はありません。"
@@ -29,19 +37,30 @@ jobs:
             DESCRIPTION="追記必須。"
           fi
 
-          {
-            echo "{"
-            echo "  \"title\": \"${{ github.event.pull_request.title }}\","
-            echo "  \"description\": \"$DESCRIPTION\","
-            echo '  "credits": ["@dependabot[bot]"]'
-            echo "}"
-          } > "$FILE"
+          jq -n \
+            --arg title "$TITLE" \
+            --arg description "$DESCRIPTION" \
+            '{
+              title: $title,
+              description: $description,
+              credits: ["@dependabot[bot]"]
+            }' > "$FILE"
 
       - name: Commit
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
 
           git add content/changelog
-          git commit -m "Add Changelog" || exit 0
-          git push
+
+          git diff --cached --quiet && exit 0
+
+          git commit -m "Add changelog for PR #$PR_NUMBER"
+
+          git remote set-url origin \
+            "https://x-access-token:${GH_TOKEN}@github.com/${{ github.repository }}.git"
+
+          git push origin HEAD:${{ github.event.pull_request.head.ref }}

--- a/.github/workflows/auto-changelog.yml
+++ b/.github/workflows/auto-changelog.yml
@@ -57,9 +57,10 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
+          BRANCH: ${{ github.event.pull_request.head.ref }}
         run: |
           git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git config user.email "41898282+github-actions[bot]`@users.noreply.github.com`"
 
           git add content/changelog
 
@@ -68,6 +69,6 @@ jobs:
           git commit -m "Add changelog for PR #$PR_NUMBER"
 
           git remote set-url origin \
-            "https://x-access-token:${GH_TOKEN}@github.com/${{ github.repository }}.git"
+            "https://x-access-token:${GH_TOKEN}`@github.com/`${{ github.repository }}.git"
 
-          git push origin HEAD:${{ github.event.pull_request.head.ref }}
+          git push origin HEAD:"$BRANCH"

--- a/.github/workflows/auto-changelog.yml
+++ b/.github/workflows/auto-changelog.yml
@@ -67,7 +67,9 @@ jobs:
 
       - name: Commit
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # GITHUB_TOKEN の push は workflow をトリガーせず、追加コミットが
+          # CI 未検証のままマージされてしまうため PAT で push する
+          GH_TOKEN: ${{ secrets.ROTARYMARS_PR_ACTION_TOKEN }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
           BRANCH: ${{ github.event.pull_request.head.ref }}
         run: |

--- a/.github/workflows/auto-changelog.yml
+++ b/.github/workflows/auto-changelog.yml
@@ -30,7 +30,7 @@ jobs:
         run: |
           mkdir -p content/changelog
 
-          FILE="content/changelog/$(printf "%04d" "$PR_NUMBER").json"
+          FILE="content/changelog/$(printf "%04d" "$PR_NUMBER")-changelog.json"
 
           if [[ "$BRANCH" == dependabot/github_actions/* ]]; then
             DESCRIPTION="Actionのバージョンを上げました。これによるページの変更はありません。"

--- a/.github/workflows/auto-changelog.yml
+++ b/.github/workflows/auto-changelog.yml
@@ -22,19 +22,19 @@ jobs:
           FILE="content/changelog/$(printf "%04d" ${{ github.event.pull_request.number }}).json"
 
           if [[ "$BRANCH" == dependabot/github_actions/* ]]; then
-          DESCRIPTION="Actionのバージョンを上げました。これによるページの変更はありません。"
+            DESCRIPTION="Actionのバージョンを上げました。これによるページの変更はありません。"
           elif [[ "$BRANCH" == dependabot/npm_and_yarn/* ]]; then
-          DESCRIPTION="パッケージのバージョンを上げました。これによるページの変更はありません。"
+            DESCRIPTION="パッケージのバージョンを上げました。これによるページの変更はありません。"
           else
-          DESCRIPTION="追記必須。"
+            DESCRIPTION="追記必須。"
           fi
 
           {
-          echo "{"
-          echo "  \"title\": \"${{ github.event.pull_request.title }}\","
-          echo "  \"description\": \"$DESCRIPTION\","
-          echo '  "credits": ["@dependabot[bot]"]'
-          echo "}"
+            echo "{"
+            echo "  \"title\": \"${{ github.event.pull_request.title }}\","
+            echo "  \"description\": \"$DESCRIPTION\","
+            echo '  "credits": ["@dependabot[bot]"]'
+            echo "}"
           } > "$FILE"
 
       - name: Commit

--- a/.github/workflows/auto-changelog.yml
+++ b/.github/workflows/auto-changelog.yml
@@ -2,17 +2,22 @@ name: Auto Changelog
 
 on:
   pull_request_target:
-    # synchronize: dependabot の recreate (force-push) でエントリが消えたら
-    # 再追加する。ワークフロー自身の GITHUB_TOKEN push は workflow を
-    # トリガーしないためループにはならない
+    # synchronize: dependabot の recreate (force-push) などでエントリが
+    # 消えたら再追加する。既にエントリがあれば何もしないためループしない
     types: [opened, synchronize]
 
 permissions:
   contents: write
 
+# 同一 PR で opened と synchronize が同時に走って push が衝突しないよう直列化
+concurrency:
+  group: auto-changelog-${{ github.event.pull_request.number }}
+
 jobs:
   create-file:
-    if: github.event.pull_request.user.login == 'dependabot[bot]'
+    # fork からの PR は対象外: pull_request_target は secrets と書き込み権限を
+    # 持つため、fork のコード (package.json など) を扱ってはいけない
+    if: github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
 
     steps:
@@ -27,26 +32,33 @@ jobs:
           BRANCH: ${{ github.event.pull_request.head.ref }}
           TITLE: ${{ github.event.pull_request.title }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
+          AUTHOR: ${{ github.event.pull_request.user.login }}
         run: |
-          mkdir -p content/changelog
-
           FILE="content/changelog/$(printf "%04d" "$PR_NUMBER")-changelog.json"
+
+          # 既にエントリがあれば上書きしない (手動で記入した説明を守る)
+          if [ -f "$FILE" ]; then
+            exit 0
+          fi
+
+          mkdir -p content/changelog
 
           if [[ "$BRANCH" == dependabot/github_actions/* ]]; then
             DESCRIPTION="Actionのバージョンを上げました。これによるページの変更はありません。"
           elif [[ "$BRANCH" == dependabot/npm_and_yarn/* ]]; then
             DESCRIPTION="パッケージのバージョンを上げました。これによるページの変更はありません。"
           else
-            DESCRIPTION="追記必須。"
+            DESCRIPTION="TODO"
           fi
 
           jq -n \
             --arg title "$TITLE" \
             --arg description "$DESCRIPTION" \
+            --arg author "@$AUTHOR" \
             '{
               title: $title,
               description: $description,
-              credits: ["@dependabot[bot]"]
+              credits: [$author]
             }' > "$FILE"
 
           # jq の整形は Prettier と一致しないため、マージ後 main の
@@ -57,6 +69,7 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
+          BRANCH: ${{ github.event.pull_request.head.ref }}
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
@@ -70,4 +83,4 @@ jobs:
           git remote set-url origin \
             "https://x-access-token:${GH_TOKEN}@github.com/${{ github.repository }}.git"
 
-          git push origin HEAD:${{ github.event.pull_request.head.ref }}
+          git push origin "HEAD:$BRANCH"

--- a/.github/workflows/auto-changelog.yml
+++ b/.github/workflows/auto-changelog.yml
@@ -1,0 +1,47 @@
+on:
+  pull_request_target:
+    types: [opened]
+
+permissions:
+  contents: write
+
+jobs:
+  create-file:
+    if: github.event.pull_request.user.login == 'dependabot[bot]'
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
+          ref: ${{ github.event.pull_request.head.ref }}
+
+      - name: Write log
+        run: |
+          BRANCH="${{ github.event.pull_request.head.ref }}"
+          FILE="content/changelog/$(printf "%04d" ${{ github.event.pull_request.number }}).json"
+
+          if [[ "$BRANCH" == dependabot/github_actions/* ]]; then
+          DESCRIPTION="Actionのバージョンを上げました。これによるページの変更はありません。"
+          elif [[ "$BRANCH" == dependabot/npm_and_yarn/* ]]; then
+          DESCRIPTION="パッケージのバージョンを上げました。これによるページの変更はありません。"
+          else
+          DESCRIPTION="追記必須。"
+          fi
+
+          {
+          echo "{"
+          echo "  \"title\": \"${{ github.event.pull_request.title }}\","
+          echo "  \"description\": \"$DESCRIPTION\","
+          echo '  "credits": ["@dependabot[bot]"]'
+          echo "}"
+          } > "$FILE"
+
+      - name: Commit
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+          git add content/changelog
+          git commit -m "Add Changelog" || exit 0
+          git push

--- a/.github/workflows/auto-changelog.yml
+++ b/.github/workflows/auto-changelog.yml
@@ -2,7 +2,10 @@ name: Auto Changelog
 
 on:
   pull_request_target:
-    types: [opened]
+    # synchronize: dependabot の recreate (force-push) でエントリが消えたら
+    # 再追加する。ワークフロー自身の GITHUB_TOKEN push は workflow を
+    # トリガーしないためループにはならない
+    types: [opened, synchronize]
 
 permissions:
   contents: write

--- a/.github/workflows/auto-changelog.yml
+++ b/.github/workflows/auto-changelog.yml
@@ -46,6 +46,10 @@ jobs:
               credits: ["@dependabot[bot]"]
             }' > "$FILE"
 
+          # jq の整形は Prettier と一致しないため、マージ後 main の
+          # format:check が落ちないようにリポジトリと同じ Prettier で整形する
+          npx --yes "prettier@$(node -p 'require("./package.json").devDependencies.prettier')" --write "$FILE"
+
       - name: Commit
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/changelog-check.yml
+++ b/.github/workflows/changelog-check.yml
@@ -19,8 +19,13 @@ jobs:
         run: |
           FOUND=0
           for f in content/changelog/*.json; do
-            if jq -e '.description | contains("TODO")' "$f" > /dev/null; then
+            STATUS=0
+            jq -e '.description | contains("TODO")' "$f" > /dev/null || STATUS=$?
+            if [ "$STATUS" -eq 0 ]; then
               echo "::error file=$f::説明が TODO のままです。マージ前に内容を記入してください。"
+              FOUND=1
+            elif [ "$STATUS" -ne 1 ]; then
+              echo "::error file=$f::JSON が不正か、description が文字列ではありません。"
               FOUND=1
             fi
           done

--- a/.github/workflows/changelog-check.yml
+++ b/.github/workflows/changelog-check.yml
@@ -1,0 +1,27 @@
+name: Changelog Check
+
+on:
+  pull_request:
+    branches: ["main"]
+    types: [opened, synchronize, reopened]
+
+permissions:
+  contents: read
+
+jobs:
+  no-todo:
+    name: No TODO in changelog
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Check changelog descriptions for TODO
+        run: |
+          FOUND=0
+          for f in content/changelog/*.json; do
+            if jq -e '.description | contains("TODO")' "$f" > /dev/null; then
+              echo "::error file=$f::説明が TODO のままです。マージ前に内容を記入してください。"
+              FOUND=1
+            fi
+          done
+          exit "$FOUND"

--- a/content/changelog/0148-changelog.json
+++ b/content/changelog/0148-changelog.json
@@ -1,0 +1,5 @@
+{
+  "title": "PR発動時などに自動でChangelogを生成",
+  "description": "PR発動時などに自動でChangelogを生成するように変更しました。これによるページの変更はありません。",
+  "credits": ["@sakaYq4875", "@rotarymars"]
+}


### PR DESCRIPTION
できれば次にdependabotの大量のPRが作られる前にマージしたいですが、その限りではありません。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores / Automation**
  * Added automated changelog generation on pull requests, creating a standardized, pre-formatted JSON entry (keyed by PR number) and committing it back to the PR branch.
  * Entries derive metadata from the pull request title, branch prefix, and author, and skip updating when already present.
* **Bug Fixes**
  * Added a changelog validation workflow that fails the pull request when any changelog JSON still contains placeholder (“TODO”) descriptions or invalid JSON.
* **Changelog**
  * Added a new generated changelog entry for PR `#148` (Dependabot-related).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->