### PR TITLE
added bypass system

### DIFF
--- a/content/changelog/0160-changelog.json
+++ b/content/changelog/0160-changelog.json
@@ -1,0 +1,5 @@
+{
+  "title": "added bypass system",
+  "description": "TODO",
+  "credits": ["@Shirym-min"]
+}

--- a/content/changelog/0160-changelog.json
+++ b/content/changelog/0160-changelog.json
@@ -1,5 +1,5 @@
 {
-  "title": "added bypass system",
-  "description": "TODO",
+  "title": "added local login bypass system",
+  "description": "ローカルの開発環境でログインをバイパスする機能を追加しました。ページに変更はありません。",
   "credits": ["@Shirym-min"]
 }

--- a/lib/session.ts
+++ b/lib/session.ts
@@ -205,12 +205,6 @@ export async function validateSessionToken(
   return validateSessionTokenViaDb(token);
 }
 
-/**
- * The logged-in user for the current request, or null. Reads the session
- * cookie, so any page using it renders dynamically. Renews the session's
- * expiry as a side effect (see validateSessionToken). Deduplicated per
- * request via React cache().
- */
 export const getCurrentUser = cache(async (): Promise<SessionUser | null> => {
   if (process.env.LOCAL_DEV_USER && process.env.NODE_ENV === "development") {
     return {

--- a/lib/session.ts
+++ b/lib/session.ts
@@ -215,8 +215,9 @@ export const getCurrentUser = cache(async (): Promise<SessionUser | null> => {
   if (process.env.LOCAL_DEV_USER && process.env.NODE_ENV === "development") {
     return {
       username: process.env.LOCAL_DEV_USER,
-      roles: (process.env.LOCAL_DEV_ROLES?.split(/[,\s]+/).filter(Boolean) ??
-        []) as string[],
+      roles: process.env.LOCAL_DEV_ROLES
+        ? process.env.LOCAL_DEV_ROLES.split(/,\s*/)
+        : [],
     };
   }
   const cookieStore = await cookies();

--- a/lib/session.ts
+++ b/lib/session.ts
@@ -212,6 +212,13 @@ export async function validateSessionToken(
  * request via React cache().
  */
 export const getCurrentUser = cache(async (): Promise<SessionUser | null> => {
+  if (process.env.LOCAL_DEV_USER && process.env.NODE_ENV === "development") {
+    return {
+      username: process.env.LOCAL_DEV_USER,
+      roles: (process.env.LOCAL_DEV_ROLES?.split(/[,\s]+/).filter(Boolean) ??
+        []) as string[],
+    };
+  }
   const cookieStore = await cookies();
   const token = cookieStore.get(SESSION_COOKIE_NAME)?.value;
   if (!token) return null;


### PR DESCRIPTION
close #145 
ローカルでDBなしでログインすることができるようになります。
使い方としては、.env.localを用意し、
``` env
LOCAL_DEV_USER=3C22
LOCAL_DEV_ROLES=Sousakuten
```
このように入力し、
``` bash
npm run dev
```
で開発用サーバーを立ち上げることでログインせずに委員用の画面をテストすることができます。
LOCAL_DEV_ROLESに別の言葉を入れれば委員以外の人が見る画面にもできます。

なお、developmentの時しか有効にならないようになっているため本番環境では動きません。（一応環境変数には入れないようにしてください）
一応作りましたが、このサイトではあまり役に立たないかもしれません

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a local development sign-in shortcut that automatically uses a configured test user and roles when running in development mode.

* **Documentation**
  * Added a new changelog entry describing the update (including author credit).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->