### PR TITLE
fix of coding style

### DIFF
--- a/components/AccountNav/AccountNavLink.tsx
+++ b/components/AccountNav/AccountNavLink.tsx
@@ -18,7 +18,7 @@ export function AccountNavLink({
   // the 2026 namespace). Modifier / middle clicks fall through to the bare
   // href so open-in-new-tab keeps working; with no JS the href is the login
   // page (you just land there without a return trip).
-  const handleClick = (event: MouseEvent<HTMLAnchorElement>) => {
+  function handleClick(event: MouseEvent<HTMLAnchorElement>) {
     if (
       event.button !== 0 ||
       event.metaKey ||
@@ -30,8 +30,17 @@ export function AccountNavLink({
     }
     event.preventDefault();
     const next = encodeURIComponent(window.location.href);
-    window.location.href = `${loginBaseUrl}?next=${next}`;
-  };
+    // Resolve against the current origin so the destination is absolute either
+    // way: loginBaseUrl is a cross-origin URL in production (the shared /login
+    // on the namespace apex) but the relative "/login" in local dev and vvps.
+    // Assigning it is a full page load on purpose — the login handoff must
+    // leave this app rather than client-route within it.
+    const target = new URL(
+      `${loginBaseUrl}?next=${next}`,
+      window.location.href,
+    );
+    window.location.assign(target.toString());
+  }
 
   const isLoggedIn = username !== null;
   return (

--- a/components/AccountNav/AccountNavLink.tsx
+++ b/components/AccountNav/AccountNavLink.tsx
@@ -40,7 +40,7 @@ export function AccountNavLink({
       window.location.href,
     );
     window.location.assign(target.toString());
-  }
+  };
 
   const isLoggedIn = username !== null;
   return (

--- a/components/AccountNav/AccountNavLink.tsx
+++ b/components/AccountNav/AccountNavLink.tsx
@@ -18,7 +18,7 @@ export function AccountNavLink({
   // the 2026 namespace). Modifier / middle clicks fall through to the bare
   // href so open-in-new-tab keeps working; with no JS the href is the login
   // page (you just land there without a return trip).
-  function handleClick(event: MouseEvent<HTMLAnchorElement>) {
+  const handleClick = (event: MouseEvent<HTMLAnchorElement>) => {
     if (
       event.button !== 0 ||
       event.metaKey ||

--- a/content/changelog/0211-changelog.json
+++ b/content/changelog/0211-changelog.json
@@ -1,0 +1,5 @@
+{
+  "title": "fix of coding style",
+  "description": "TODO",
+  "credits": ["@rotarymars"]
+}

--- a/content/changelog/0211-changelog.json
+++ b/content/changelog/0211-changelog.json
@@ -1,5 +1,5 @@
 {
-  "title": "fix of coding style",
-  "description": "TODO",
+  "title": "内部コードの修正",
+  "description": "ページ内のコードを一部修正しました。これによるページの変更はありません。",
   "credits": ["@rotarymars"]
 }


### PR DESCRIPTION
This fixes the warning that is generated from eslint-config-next 16.3.0

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/KSS-IT-Committee/codesmith/2026-sousakuten-info/pr/211"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788957838&installation_model_id=427714&pr_number=211&repository=KSS-IT-Committee%2F2026-sousakuten-info&return_to=https%3A%2F%2Fgithub.com%2FKSS-IT-Committee%2F2026-sousakuten-info%2Fpull%2F211&signature=e2c737445ebb97ba9c704b8be86c582e4fea510278ae2eeb1d8a38cb1d4f1423"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved login navigation to reliably open the configured login destination.
  - Ensured login redirects perform a complete page navigation for more consistent behavior across pages.

- **Documentation**
  - Added a Japanese changelog entry documenting internal page-code updates.
  - Clarified that these updates do not introduce visible page changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->